### PR TITLE
fix: await CSP generation in vite plugin closeBundle hook

### DIFF
--- a/packages/vite-bun/src/index.ts
+++ b/packages/vite-bun/src/index.ts
@@ -30,9 +30,9 @@ export const generateCspPlugin = (options: CspPluginConfiguration = {}): PluginO
     },
     closeBundle: {
       order: "post",
-      handler: () => {
+      handler: async () => {
         const policy = { ...startingPolicy };
-        handler({ algorithm, config, policy, BunFile, BunHash });
+        await handler({ algorithm, config, policy, BunFile, BunHash });
       },
     },
   };

--- a/test/closeBundle.test.ts
+++ b/test/closeBundle.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { generateCspPlugin } from "../packages/vite-bun/src";
+
+describe("generateCspPlugin closeBundle", () => {
+  test("closeBundle.handler returns a Promise, and the CSP is written by the time it resolves", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vite-plugin-csp-"));
+
+    try {
+      await Bun.write(
+        join(dir, "index.html"),
+        '<html><head><meta http-equiv="Content-Security-Policy" content="" /></head><body></body></html>',
+      );
+
+      // biome-ignore lint/suspicious/noExplicitAny: PluginOption is a broad union; narrow it for direct hook access in this test.
+      const plugin = generateCspPlugin() as any;
+
+      // Mimic what Vite does before closeBundle: call configResolved once.
+      plugin.configResolved({ root: dir, base: "/", build: { outDir: "." } });
+
+      const result = plugin.closeBundle.handler();
+
+      expect(result).toBeInstanceOf(Promise);
+
+      await result;
+
+      const html = await Bun.file(join(dir, "index.html")).text();
+
+      expect(html).not.toContain('content=""');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

`generateCspPlugin`'s `closeBundle` hook called the async CSP-generation
`handler(...)` without awaiting it or returning its promise. Rollup only
waits for a hook if the hook itself returns a promise — `closeBundle` is
one of Rollup's async-capable hooks precisely for this reason.

Because the promise was silently dropped:

- Vite considered the build "done" before the CSP file write actually
  finished, so any process that exits promptly after `vite build` returns
  (CI runners, containerized builds) could ship `index.html` with **no
  CSP/SRI injected at all** — a silent, timing-dependent failure.
- If the async work threw, the rejection became an unhandled promise
  rejection instead of a build failure.

## Fix

Two-line change: mark the hook `async` and `await` the call.

## Testing

Added `test/closeBundle.test.ts`, a regression test that builds a scratch
HTML file, drives the plugin's hooks directly, and asserts
`closeBundle.handler()` returns a `Promise` and the CSP is written by the
time it resolves. Confirmed this test is a genuine regression test by
temporarily reverting to the pre-fix code and observing it fail
(`Received value: undefined` instead of a `Promise`).

Full verification re-run independently: `tsc --noEmit`, `bun run test`
(15/15 pass), `bun run lint`, and `git status` scope check.

## Provenance

Generated via the `/improve` audit skill; full investigation, evidence,
and done criteria are in `plans/001-vite-plugin-await-closebundle.md` on
`main` (untracked in this branch — the plan predates this PR).

🤖 Generated with the assistance of GitHub Copilot CLI.
