### PR TITLE
fix: skip SRI hash for remote assets when the fetch response is not ok

### DIFF
--- a/packages/shared/BaseHandler.ts
+++ b/packages/shared/BaseHandler.ts
@@ -43,6 +43,14 @@ export class BaseHandler {
   protected getFileContents = async (assetPath: string): Promise<string> => {
     if (assetPath.startsWith("https://")) {
       const response = await fetch(assetPath);
+
+      if (!response.ok) {
+        console.warn(
+          `[vite-plugin-csp] Failed to fetch ${assetPath} (status ${response.status}); skipping integrity hash for this asset.`,
+        );
+        return "";
+      }
+
       return await response.text();
     }
 

--- a/test/getFileContents.test.ts
+++ b/test/getFileContents.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { BunFile } from "../packages/shared/BunFile";
+import { BunHash } from "../packages/shared/BunHash";
+import { ScriptHandler } from "../packages/shared/ScriptHandler";
+
+const makeElement = (attrs: Record<string, string>) => ({
+  getAttribute: (name: string) => attrs[name] ?? null,
+  hasAttribute: (name: string) => name in attrs,
+  setAttribute: (name: string, value: string) => {
+    attrs[name] = value;
+  },
+});
+
+describe("getFileContents (via ScriptHandler)", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("does not set an integrity attribute when the remote fetch returns a non-ok status", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: minimal fetch mock for this test.
+    globalThis.fetch = mock(async () => new Response("Not Found", { status: 404 })) as any;
+
+    const config = { base: "", outDir: "", root: "." };
+    const handler = new ScriptHandler("sha256", config, BunHash, BunFile);
+
+    const element = makeElement({ src: "https://example.com/missing.js" });
+
+    // biome-ignore lint/suspicious/noExplicitAny: minimal mock of the HTMLRewriter Element interface for this test.
+    await handler.element(element as any);
+
+    expect(element.getAttribute("integrity")).toBeNull();
+  });
+
+  test("still sets an integrity attribute when the remote fetch succeeds", async () => {
+    // biome-ignore lint/suspicious/noExplicitAny: minimal fetch mock for this test.
+    globalThis.fetch = mock(async () => new Response("console.log('ok')", { status: 200 })) as any;
+
+    const config = { base: "", outDir: "", root: "." };
+    const handler = new ScriptHandler("sha256", config, BunHash, BunFile);
+
+    const element = makeElement({ src: "https://example.com/present.js" });
+
+    // biome-ignore lint/suspicious/noExplicitAny: minimal mock of the HTMLRewriter Element interface for this test.
+    await handler.element(element as any);
+
+    expect(element.getAttribute("integrity")).toStartWith("sha256-");
+  });
+});


### PR DESCRIPTION
## What

`BaseHandler.getFileContents` fetches remote script/stylesheet URLs at
build time and hashes the response body to produce the SRI `integrity`
attribute. It never checked `response.ok`. If the fetch returned a 404/5xx
(transient network blip, moved asset, CDN hiccup), the error page's body
got hashed and written into `integrity` as if it were the real asset. At
runtime, the browser fetches the actual resource, the hash mismatches, and
the browser **blocks it** — a legitimate resource silently broken in
production with no build-time signal.

## Fix

Check `response.ok` before hashing. On failure: log a `console.warn` and
return `""`, matching the existing local-file-failure convention in the
same function (which already returns `""` rather than throwing). Callers
(`ScriptHandler`, `StyleHandler`) already no-op on a falsy result, so no
other changes were needed.

## Testing

Added `test/getFileContents.test.ts` (2 tests, via `ScriptHandler` with a
mocked `fetch`): confirms a 404 response does NOT set `integrity`, and a
200 response still does (guards against an overly broad fix breaking the
happy path).

Full verification re-run independently: `tsc --noEmit`, the 2 new tests,
`bun run lint`, and the full `bun run test` suite (15/15 pass after
building fixtures) — all pass. `git status` scope check clean.

## Provenance

Generated via the `/improve` audit skill; full investigation and done
criteria are in `plans/004-check-fetch-response-ok.md` on `main`.

🤖 Generated with the assistance of GitHub Copilot CLI.
