### PR TITLE
fix: dedupe stylesheet origins by URL origin instead of host

### DIFF
--- a/packages/shared/StyleHandler.ts
+++ b/packages/shared/StyleHandler.ts
@@ -64,7 +64,7 @@ export class StyleHandler extends BaseHandler implements MyHTMLRewriterTypes.HTM
 
   private saveUrl = (fileUrl: string) => {
     const baseUrl = new URL(fileUrl);
-    if (!this.urlCache.includes(baseUrl.host) || !this.urlCache.includes(baseUrl.origin)) {
+    if (!this.urlCache.includes(baseUrl.origin)) {
       this.urlCache.push(baseUrl.origin);
     }
   };

--- a/test/styleHandler.test.ts
+++ b/test/styleHandler.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { BunFile } from "../packages/shared/BunFile";
+import { BunHash } from "../packages/shared/BunHash";
+import { StyleHandler } from "../packages/shared/StyleHandler";
+
+const makeElement = (attrs: Record<string, string>) => ({
+  getAttribute: (name: string) => attrs[name] ?? null,
+  hasAttribute: (name: string) => name in attrs,
+  setAttribute: (name: string, value: string) => {
+    attrs[name] = value;
+  },
+});
+
+describe("StyleHandler", () => {
+  test("dedupes repeated stylesheet origins in the generated urls list", async () => {
+    const config = { base: "", outDir: "", root: "." };
+    const handler = new StyleHandler("sha256", config, BunHash, BunFile);
+
+    await handler.element(
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock of the HTMLRewriter Element interface for this test.
+      makeElement({ rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Roboto" }) as any,
+    );
+    await handler.element(
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock of the HTMLRewriter Element interface for this test.
+      makeElement({ rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Lato" }) as any,
+    );
+
+    expect(handler.urls).toBe("https://fonts.googleapis.com");
+  });
+
+  test("keeps distinct origins separate", async () => {
+    const config = { base: "", outDir: "", root: "." };
+    const handler = new StyleHandler("sha256", config, BunHash, BunFile);
+
+    await handler.element(
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock of the HTMLRewriter Element interface for this test.
+      makeElement({ rel: "stylesheet", href: "https://fonts.googleapis.com/css2?family=Roboto" }) as any,
+    );
+    await handler.element(
+      // biome-ignore lint/suspicious/noExplicitAny: minimal mock of the HTMLRewriter Element interface for this test.
+      makeElement({ rel: "stylesheet", href: "https://cdn.example.com/css2?family=OpenSans" }) as any,
+    );
+
+    expect(handler.urls).toBe("https://fonts.googleapis.com https://cdn.example.com");
+  });
+});


### PR DESCRIPTION
## What

`StyleHandler` tracks external stylesheet origins to add them to the
generated CSP's `style-src` (and, for Google Fonts, `font-src`). Its dedup
check was broken: it checked whether the cache contained `baseUrl.host`
(e.g. `"fonts.googleapis.com"`), but the cache only ever stored
`baseUrl.origin` (e.g. `"https://fonts.googleapis.com"`) — those two
strings never match, so the "already seen" branch never fired.

Reproduced directly: 3 Google Fonts `<link>` tags with the same origin
produced `"https://fonts.googleapis.com https://fonts.googleapis.com
https://fonts.googleapis.com"` in the CSP instead of a single deduped
entry. Any app with more than one stylesheet from the same external
origin — the most common case being exactly the Google Fonts setup this
project advertises as a first-class feature — ships a bloated,
duplicated CSP.

## Fix

One-line fix: compare against `baseUrl.origin` only (drop the broken
`baseUrl.host` half of the OR condition).

## Testing

Added `test/styleHandler.test.ts` (2 tests): confirms repeated same-origin
stylesheet links collapse to one entry, and those from genuinely distinct
origins are both kept. Full verification re-run independently: `tsc
--noEmit`, the 2 new tests, `bun run lint`, full `bun run test` (15/15),
and the existing `google-fonts` e2e spec (2/2, both `bun-cli` and
`bun-vite` projects) — all pass.

## Provenance

Generated via the `/improve` audit skill; full investigation and done
criteria are in `plans/003-fix-stylehandler-dedup.md` on `main`.

🤖 Generated with the assistance of GitHub Copilot CLI.
