### PR TITLE
fix: add friendly error handling around CLI config loading and execution

### DIFF
--- a/packages/cli-bun/src/index.ts
+++ b/packages/cli-bun/src/index.ts
@@ -36,16 +36,29 @@ Options:
 const resolveConfig = async (configFilePath: string): Promise<CspPluginConfiguration> => {
   const exists = await Bun.file(configFilePath).exists();
 
-  if (exists) {
-    const imported = await import(pathToFileURL(configFilePath).href);
-
-    return imported?.default as CspPluginConfiguration;
+  if (!exists) {
+    return {
+      algorithm: "sha384",
+      policy: DEFAULT_CSP_POLICY,
+    };
   }
 
-  return {
-    algorithm: "sha384",
-    policy: DEFAULT_CSP_POLICY,
-  };
+  try {
+    const imported = await import(pathToFileURL(configFilePath).href);
+
+    if (!imported?.default) {
+      fatalError(`Config file ${configFilePath} does not have a default export.`);
+    }
+
+    return imported.default as CspPluginConfiguration;
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("Config file")) {
+      throw error; // re-throw fatalError's own path if it somehow didn't exit
+    }
+    return fatalError(
+      `Failed to load config file ${configFilePath}: ${error instanceof Error ? error.message : error}`,
+    );
+  }
 };
 
 const infoLog = (message: string): void => {
@@ -169,4 +182,8 @@ if (htmlPaths.length === 0) {
   fatalError(`No HTML files found in ${pluginConfig.root}`);
 }
 
-await handler({ algorithm, config: pluginConfig, policy, BunFile, BunHash, htmlPaths });
+try {
+  await handler({ algorithm, config: pluginConfig, policy, BunFile, BunHash, htmlPaths });
+} catch (error) {
+  fatalError(`Failed to generate CSP: ${error instanceof Error ? error.message : error}`);
+}

--- a/test/cliErrorHandling.test.ts
+++ b/test/cliErrorHandling.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { $ } from "bun";
+
+describe("csp-bun-cli error handling", () => {
+  test("exits with a friendly error when the config file has no default export", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vite-plugin-csp-cli-"));
+
+    try {
+      await writeFile(join(dir, "index.html"), "<html><head></head><body></body></html>");
+      const configPath = join(dir, "csp.config.ts");
+      await writeFile(configPath, "export const notDefault = {};");
+
+      const result = await $`bun run ./packages/cli-bun/src/index.ts --dir ${dir} --config ${configPath}`
+        .nothrow()
+        .quiet();
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.toString()).toContain("Error:");
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What

The CLI already has a `fatalError` helper (clean `Error: <message>` +
usage hint + exit 1) used consistently for argument-parsing mistakes, but
the two places most likely to fail for a real user had zero error
handling:

- `resolveConfig` destructured `imported?.default` with no check. A config
  file that exists but has no `default` export (an easy mistake — the
  README shows `export default { ... }`) produced a raw `TypeError: Cannot
  destructure property 'algorithm' of 'undefined'` instead of a friendly
  message.
- The final `await handler(...)` call had no try/catch, so any failure
  during CSP generation (missing `index.html`, bad path) surfaced as an
  unhandled exception with a full stack trace.

## Fix

- `resolveConfig` now calls `fatalError(...)` with a clear message when the
  config has no default export, and wraps the dynamic `import()` in a
  try/catch for load failures.
- The final `handler(...)` call is now wrapped in a try/catch that routes
  failures through the same `fatalError` helper.

## Testing

Added `test/cliErrorHandling.test.ts`: spawns the real CLI binary as a
subprocess against a scratch config file with no default export, asserts
exit code 1 and a friendly `Error:` message on stderr.

I additionally manually verified the second error path (Step 2) by
pointing the CLI at an empty directory:
```
$ bun run ./packages/cli-bun/src/index.ts --dir /tmp/empty-cli-test
Error: Failed to generate CSP: ENOENT: no such file or directory, open '/tmp/empty-cli-test/index.html'
Use -h or --help to see available options.
```
(exit code 1, clean message — previously this would have been a raw stack
trace.)

Full verification re-run independently: `tsc --noEmit`, the new test,
`bun run lint`, and the full `bun run test` suite (15/15) — all pass.

## Provenance

Generated via the `/improve` audit skill; full investigation and done
criteria are in `plans/005-cli-error-handling.md` on `main`.

🤖 Generated with the assistance of GitHub Copilot CLI.
