### PR TITLE
feat: support multi-page apps in vite plugin and CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ The packages automatically:
 2. Detect and handle Google Fonts in HTML
 3. Insert computed hashes into CSP meta tags
 4. Support configurable hash algorithms (SHA-256, SHA-384, SHA-512)
+5. Process all HTML files in a build output — multi-page apps (MPA) are fully supported; every discovered page gets its own independently-computed CSP
 
 ### Key Components (packages/shared/)
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "packages/cli-bun": {
       "name": "csp-bun-cli",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "bin": {
         "csp": "./dist/index.js",
       },
@@ -32,7 +32,7 @@
     },
     "packages/vite-bun": {
       "name": "vite-plugin-bun-csp",
-      "version": "2.1.2",
+      "version": "2.1.3",
       "devDependencies": {
         "@tsconfig/bun": "catalog:",
         "@types/bun": "catalog:",
@@ -62,6 +62,12 @@
         "@types/react": "^19.0.7",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^4.3.4",
+        "vite-plugin-bun-csp": "workspace:*",
+      },
+    },
+    "test/fixtures/multi-page": {
+      "name": "multi-page-fixture",
+      "devDependencies": {
         "vite-plugin-bun-csp": "workspace:*",
       },
     },
@@ -648,6 +654,8 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "mui-example": ["mui-example@workspace:test/fixtures/mui"],
+
+    "multi-page-fixture": ["multi-page-fixture@workspace:test/fixtures/multi-page"],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 

--- a/packages/cli-bun/README.md
+++ b/packages/cli-bun/README.md
@@ -67,3 +67,7 @@ csp -d path/to/dist/dir --config path/to/config.ts
 # Base Path
 csp -d path/to/dist/dir --base myapp
 ```
+
+## Multi-page apps
+
+`csp-bun-cli` automatically discovers and processes every `.html` file under the target directory. Point `--dir` at your build output root and all pages — including those in subdirectories — will receive their own independently-computed CSP and SRI `integrity` attributes.

--- a/packages/cli-bun/src/index.ts
+++ b/packages/cli-bun/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
 
 import { join, resolve } from "node:path";
+import { Glob } from "bun";
 import { handler } from "shared/BunHandler";
 import type { Config } from "shared/internal";
 
@@ -157,4 +158,15 @@ const pluginConfig: Config = {
   root: dir,
 };
 
-await handler({ algorithm, config: pluginConfig, policy, BunFile, BunHash });
+const glob = new Glob("**/*.html");
+const htmlPaths: string[] = [];
+
+for await (const file of glob.scan({ cwd: pluginConfig.root })) {
+  htmlPaths.push(join(pluginConfig.root, file));
+}
+
+if (htmlPaths.length === 0) {
+  fatalError(`No HTML files found in ${pluginConfig.root}`);
+}
+
+await handler({ algorithm, config: pluginConfig, policy, BunFile, BunHash, htmlPaths });

--- a/packages/shared/BunHandler.ts
+++ b/packages/shared/BunHandler.ts
@@ -15,11 +15,28 @@ interface HandlerArgs {
   policy: CspPolicy;
   BunHash: HasherContructor;
   BunFile: CspFileContructor;
+  /** Absolute paths of every HTML file to process. Defaults to a single `index.html` at the build root for backward compatibility. */
+  htmlPaths?: string[];
 }
 
-export const handler = async ({ algorithm, config, BunHash, BunFile, policy }: HandlerArgs) => {
-  const htmlPath = resolvePath("index.html", config);
+export const handler = async ({ algorithm, config, BunHash, BunFile, policy, htmlPaths }: HandlerArgs) => {
+  const paths = htmlPaths ?? [resolvePath("index.html", config)];
 
+  for (const htmlPath of paths) {
+    await processHtmlFile({ htmlPath, algorithm, config, policy: { ...policy }, BunHash, BunFile });
+  }
+};
+
+interface ProcessHtmlFileArgs {
+  htmlPath: string;
+  algorithm: HashAlgorithm;
+  config: Config;
+  policy: CspPolicy;
+  BunHash: HasherContructor;
+  BunFile: CspFileContructor;
+}
+
+const processHtmlFile = async ({ htmlPath, algorithm, config, policy, BunHash, BunFile }: ProcessHtmlFileArgs) => {
   const htmlFile = new BunFile(htmlPath);
 
   const originalHtml = await htmlFile.read();
@@ -36,10 +53,6 @@ export const handler = async ({ algorithm, config, BunHash, BunFile, policy }: H
     .on("style", inlineStyleHandler)
     .transform(new Response(originalHtml));
 
-  // Content handlers above perform async file reads / fetches, so we must
-  // pass a Response and await its body instead of transforming a string
-  // synchronously. As of Bun 1.4, HTMLRewriter throws if a handler's Promise
-  // doesn't resolve within a microtask when transforming a string directly.
   const newHtml = await newHtmlResponse.text();
 
   const csp = buildCsp(policy, { scriptHandler, inlineScriptHandler, styleHandler, inlineStyleHandler });

--- a/packages/vite-bun/README.md
+++ b/packages/vite-bun/README.md
@@ -69,3 +69,7 @@ export default defineConfig({
   ],
 });
 ```
+
+## Multi-page apps
+
+`vite-plugin-bun-csp` supports Vite's [multi-page app](https://vite.dev/guide/build.html#multi-page-app) pattern out of the box. Every HTML file that Vite emits (via `build.rollupOptions.input`) is automatically discovered and processed — no additional configuration needed. Each page gets its own independently-computed CSP and SRI `integrity` attributes.

--- a/packages/vite-bun/src/index.ts
+++ b/packages/vite-bun/src/index.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import { BunFile } from "shared/BunFile";
 import { handler } from "shared/BunHandler";
 import { BunHash } from "shared/BunHash";
@@ -28,11 +29,18 @@ export const generateCspPlugin = (options: CspPluginConfiguration = {}): PluginO
         root,
       };
     },
-    closeBundle: {
+    writeBundle: {
       order: "post",
-      handler: () => {
+      handler: async (options, bundle) => {
+        const outDir = options.dir;
+
+        const htmlPaths = Object.values(bundle)
+          .filter((entry) => entry.fileName.endsWith(".html"))
+          .map((entry) => join(outDir ?? config.root, entry.fileName));
+
         const policy = { ...startingPolicy };
-        handler({ algorithm, config, policy, BunFile, BunHash });
+
+        await handler({ algorithm, config, policy, BunFile, BunHash, htmlPaths });
       },
     },
   };

--- a/test/e2e/multi-page.spec.ts
+++ b/test/e2e/multi-page.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "@playwright/test";
+
+test("injects a working CSP into the home page", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText("Home")).toBeVisible();
+
+  const content = await page.locator('meta[http-equiv="Content-Security-Policy"]').getAttribute("content");
+  expect(content).toBeTruthy();
+  expect(content).toContain("script-src");
+});
+
+test("injects a working CSP into a nested page", async ({ page }) => {
+  await page.goto("/about/index.html");
+  await expect(page.getByText("About")).toBeVisible();
+
+  const content = await page.locator('meta[http-equiv="Content-Security-Policy"]').getAttribute("content");
+  expect(content).toBeTruthy();
+  expect(content).toContain("script-src");
+});

--- a/test/fixtures/multi-page/_vite.config.ts
+++ b/test/fixtures/multi-page/_vite.config.ts
@@ -1,0 +1,18 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+import { generateCspPlugin } from "vite-plugin-bun-csp";
+
+const root = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  plugins: [generateCspPlugin()],
+  build: {
+    rollupOptions: {
+      input: {
+        main: resolve(root, "index.html"),
+        about: resolve(root, "about/index.html"),
+      },
+    },
+  },
+});

--- a/test/fixtures/multi-page/about.js
+++ b/test/fixtures/multi-page/about.js
@@ -1,0 +1,1 @@
+console.log("about");

--- a/test/fixtures/multi-page/about/index.html
+++ b/test/fixtures/multi-page/about/index.html
@@ -1,0 +1,9 @@
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Security-Policy" content="" />
+  </head>
+  <body>
+    <h1>About</h1>
+    <script type="module" src="../about.js"></script>
+  </body>
+</html>

--- a/test/fixtures/multi-page/index.html
+++ b/test/fixtures/multi-page/index.html
@@ -1,0 +1,9 @@
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Security-Policy" content="" />
+  </head>
+  <body>
+    <h1>Home</h1>
+    <script type="module" src="./main.js"></script>
+  </body>
+</html>

--- a/test/fixtures/multi-page/main.js
+++ b/test/fixtures/multi-page/main.js
@@ -1,0 +1,1 @@
+console.log("home");

--- a/test/fixtures/multi-page/package.json
+++ b/test/fixtures/multi-page/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "multi-page-fixture",
+  "type": "module",
+  "private": true,
+  "devDependencies": {
+    "vite-plugin-bun-csp": "workspace:*"
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readdir } from "node:fs/promises";
 import { resolve } from "node:path";
+import { Glob } from "bun";
 import type { Target } from "../scripts/fixtures";
 
 const basePath = resolve(__dirname, "./fixtures");
@@ -9,15 +10,26 @@ const fixtures = await readdir(basePath);
 
 describe("vite-plugin-csp", () => {
   test.each(fixtures)("%s", async (fixture) => {
-    const vite = await readHtml(fixture, "bun-vite");
-    const cli = await readHtml(fixture, "bun-cli");
+    const vitePages = await findHtmlPages(fixture, "bun-vite");
+    const cliPages = await findHtmlPages(fixture, "bun-cli");
 
-    expect(vite).toEqual(cli);
+    expect(cliPages.map((p) => p.relativePath).sort()).toEqual(vitePages.map((p) => p.relativePath).sort());
+
+    for (const page of vitePages) {
+      const match = cliPages.find((p) => p.relativePath === page.relativePath);
+      expect(match?.contents).toEqual(page.contents);
+    }
   });
 });
 
-const readHtml = async (path: string, target: Target): Promise<string> => {
-  const htmlPath = resolve(basePath, path, "dist", target, "index.html");
+const findHtmlPages = async (fixture: string, target: Target) => {
+  const distDir = resolve(basePath, fixture, "dist", target);
+  const glob = new Glob("**/*.html");
+  const pages: { relativePath: string; contents: string }[] = [];
 
-  return await Bun.file(htmlPath).text();
+  for await (const file of glob.scan({ cwd: distDir })) {
+    pages.push({ relativePath: file, contents: await Bun.file(resolve(distDir, file)).text() });
+  }
+
+  return pages;
 };


### PR DESCRIPTION
Closes #26.

## What

Vite natively supports multi-page apps via `build.rollupOptions.input`
with several HTML entry points, but this plugin didn't: both `vite-bun`
and `cli-bun` hardcoded processing exactly one file, literally named
`index.html`, at the build root.

This was verified empirically before writing the plan, not just inferred
from reading the code:

1. **The Vite plugin silently skipped every page except the root one.** A
   two-page build (`index.html` + `about/index.html`, each with its own
   script) built fine, but only `index.html` got a real CSP/SRI —
   `about/index.html` was left with an empty `content=""` CSP and no
   `integrity` attribute at all. No error, no warning.
2. **There was no working manual workaround via the CLI either.** Pointing
   `csp-bun-cli --dir dist/about` at the nested page's directory found the
   HTML file, but crashed with `ENOENT` — Vite hoists shared, hashed JS/CSS
   chunks into one `assets/` folder at the *true* build root regardless of
   which nested page references them, and there was no way to point the
   CLI at "this HTML file" separately from "the real assets root."

## Fix

- `shared/BunHandler.ts`: `handler()` now accepts an optional `htmlPaths`
  list and loops over every discovered page with a **fresh policy copy per
  page** (so hash sets never leak between pages). Defaults to the old
  single-`index.html` behavior when `htmlPaths` is omitted.
- `vite-bun`: switched from Rollup's `closeBundle` hook to `writeBundle`,
  which has access to every file Rollup actually emitted — discovers every
  `.html` output and processes each one.
- `cli-bun`: added a `**/*.html` glob scan under `--dir` to discover every
  page instead of assuming a single `index.html`.
- Added a `multi-page` test fixture (home + nested page), generalized the
  CLI/plugin parity test to compare every discovered HTML file (not just
  the root one), and added e2e coverage for both pages.
- Documented the feature in both package READMEs and `AGENTS.md`.

## ⚠️ Known overlaps with other open PRs from the same audit

This PR was built independently against `main` (not stacked on other
branches), so two things are worth knowing before merging:

1. **Supersedes #288** (`fix: await CSP generation in vite plugin
   closeBundle hook`). That PR patches the old `closeBundle` hook;
   this PR removes that hook entirely in favor of `writeBundle` (needed
   because `closeBundle` can't see the list of emitted files). **#288
   should be closed, not merged, once this lands** — I've marked it
   accordingly.
2. **Touches the same region as #293** (`fix: add friendly error handling
   around CLI config loading and execution`), which wraps `cli-bun`'s
   final `handler(...)` call in a try/catch. This PR inserts HTML-discovery
   code immediately before that same call. Whichever of #293/this PR
   merges second will hit a small, easy-to-resolve conflict in
   `packages/cli-bun/src/index.ts` (both features can coexist — the
   try/catch should simply wrap the `handler(...)` call after the glob
   discovery runs).

## Testing

Manually confirmed the actual bug is fixed by inspecting real build
output — the nested page now gets its own correct, independently-hashed
CSP:
```
dist/bun-vite/about/index.html:
<meta http-equiv="Content-Security-Policy" content="base-uri 'none'; default-src 'self'; object-src 'none'; script-src 'sha384-eqbAHZ...' 'strict-dynamic'" />
<script type="module" crossorigin src="/assets/about-Beozjq1z.js" integrity="sha384-eqbAHZ..."></script>
```
(different hash from the home page's, and identical between the CLI and
Vite-plugin outputs).

Full verification re-run independently: `tsc --noEmit` (both packages),
`bun run build`, `bun run lint`, `bun run build_fixtures`, `bun run test`
(16/16, including `multi-page`), and `bun run e2e` (**34/34**, including
4 new multi-page tests across both `bun-cli` and `bun-vite` projects).

## Open questions (deliberately deferred, not part of this PR)

- Should the CLI support `--include`/`--exclude` glob patterns for HTML
  discovery, for output trees with incidental non-page HTML?
- Should different pages be able to use different CSP policies? Nothing
  in the current issue or codebase suggests this is needed yet.

## Provenance

Generated via the `/improve` audit skill; full investigation, evidence,
and done criteria are in `plans/007-mpa-support.md` on `main`.

🤖 Generated with the assistance of GitHub Copilot CLI.
