### PR TITLE
chore: remove unused generateId and ID_ATT_NAME exports

### DIFF
--- a/packages/shared/InlineScriptHandler.ts
+++ b/packages/shared/InlineScriptHandler.ts
@@ -1,8 +1,6 @@
 import { BaseHandler } from "./BaseHandler";
 import type { MyHTMLRewriterTypes } from "./internal";
 
-export const ID_ATT_NAME = "x-vite-plugin-csp";
-
 export class InlineScriptHandler extends BaseHandler implements MyHTMLRewriterTypes.HTMLRewriterElementContentHandlers {
   private textContent = "";
 

--- a/packages/shared/utils.ts
+++ b/packages/shared/utils.ts
@@ -1,4 +1,3 @@
-import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 import type { Config, Handlers } from "./internal";
 import type { CspPolicy } from "./types";
@@ -58,10 +57,6 @@ export const addToPolicy = (policy: CspPolicy, directive: keyof CspPolicy, hashV
 
 export const resolvePath = (filepath: string, { base, outDir, root }: Config) => {
   return join(root, outDir, filepath.replace(base, ""));
-};
-
-export const generateId = () => {
-  return randomBytes(16).toString("hex");
 };
 
 /**


### PR DESCRIPTION
## What

Two exported symbols in `packages/shared` had zero references anywhere
else in the repository (confirmed with a repo-wide search across
`packages/`, `test/`, `scripts/`, and `*.md`): `generateId()` in
`utils.ts` and `ID_ATT_NAME` in `InlineScriptHandler.ts`. Almost certainly
leftovers from an earlier design (e.g. correlating elements via a marker
attribute + random ID, later replaced by the current buffer-based text
accumulation). Dead exported code in a small shared module costs future
readers time wondering "is this used somewhere I'm missing?"

## Fix

Removed both, plus the now-unused `randomBytes` import that only
`generateId` used. Pure deletion — no behavioral surface.

## Testing

Full verification re-run independently: confirmed zero remaining
references via grep, `bun run lint`, `bun run build` (both packages),
`bun run test` (15/15), and `bun run e2e` (**30/30**) — all pass.

## Provenance

Generated via the `/improve` audit skill; full investigation and done
criteria are in `plans/006-remove-dead-exports.md` on `main`.

🤖 Generated with the assistance of GitHub Copilot CLI.
