### PR TITLE
feat(cli): add --pattern flag for customizing HTML file discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build_fixtures": "bun scripts/fixtures.ts",
     "clean": "bun scripts/clean.ts",
     "lint": "biome ci .",
-    "test": "bun test ./test/index.test.ts",
+    "test": "bun test ./test/index.test.ts ./test/cli-pattern.test.ts",
     "e2e": "bunx playwright test"
   },
   "devDependencies": {

--- a/packages/cli-bun/README.md
+++ b/packages/cli-bun/README.md
@@ -66,8 +66,23 @@ csp -d path/to/dist/dir --config path/to/config.ts
 
 # Base Path
 csp -d path/to/dist/dir --base myapp
+
+# Custom file pattern
+csp -d path/to/dist/dir --pattern "*.html"
 ```
 
 ## Multi-page apps
 
 `csp-bun-cli` automatically discovers and processes every `.html` file under the target directory. Point `--dir` at your build output root and all pages — including those in subdirectories — will receive their own independently-computed CSP and SRI `integrity` attributes.
+
+## Custom file patterns
+
+By default, `csp-bun-cli` recursively matches every HTML file under `--dir` using the glob pattern `**/*.html`. Use `--pattern` to narrow or widen which files get processed:
+
+```bash
+# Only top-level HTML files, skip nested pages
+csp -d path/to/dist/dir --pattern "*.html"
+
+# Match both .html and .htm files
+csp -d path/to/dist/dir --pattern "**/*.{html,htm}"
+```

--- a/packages/cli-bun/src/index.ts
+++ b/packages/cli-bun/src/index.ts
@@ -18,6 +18,7 @@ interface ProgramOptions {
   dir?: string;
   config?: string;
   base?: string;
+  pattern?: string;
 }
 
 const helpText = `
@@ -30,6 +31,7 @@ Options:
   -d, --dir <directory>  Directory with the HTML file to process. (default: ".")
   -c, --config <file>    Path to CSP config file. (default: "csp.config.ts")
   -b, --base <path>      Base public path of your SPA. (default: "")
+  -p, --pattern <glob>   Glob pattern (relative to --dir) used to find HTML files. (default: "**/*.html")
   -h, --help             display help for command
 `;
 
@@ -77,6 +79,7 @@ const parseAgs = (): Required<ProgramOptions> => {
     base: "",
     dir: process.cwd(), // Default to current working directory
     config: join(process.cwd(), "csp.config.ts"), // Default config file path
+    pattern: "**/*.html", // Default glob pattern for finding HTML files
   };
 
   // Parse command line arguments into an array of strings
@@ -139,6 +142,17 @@ const parseAgs = (): Required<ProgramOptions> => {
         }
         break;
       }
+      case "-p":
+      case "--pattern": {
+        const patternValue = args[i + 1];
+        if (patternValue) {
+          config.pattern = patternValue.trim();
+          i++;
+        } else {
+          fatalError("Pattern argument is missing a value.");
+        }
+        break;
+      }
       case "-h":
       case "--help": {
         infoLog(helpText);
@@ -159,7 +173,7 @@ const parseAgs = (): Required<ProgramOptions> => {
   return config;
 };
 
-const { dir, base, config } = parseAgs();
+const { dir, base, config, pattern } = parseAgs();
 
 const cspConfig = await resolveConfig(config);
 
@@ -171,7 +185,7 @@ const pluginConfig: Config = {
   root: dir,
 };
 
-const glob = new Glob("**/*.html");
+const glob = new Glob(pattern);
 const htmlPaths: string[] = [];
 
 for await (const file of glob.scan({ cwd: pluginConfig.root })) {
@@ -179,7 +193,7 @@ for await (const file of glob.scan({ cwd: pluginConfig.root })) {
 }
 
 if (htmlPaths.length === 0) {
-  fatalError(`No HTML files found in ${pluginConfig.root}`);
+  fatalError(`No HTML files found in ${pluginConfig.root} matching pattern "${pattern}"`);
 }
 
 try {

--- a/test/cli-pattern.test.ts
+++ b/test/cli-pattern.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { $ } from "bun";
+
+const cliPath = join(import.meta.dir, "../packages/cli-bun/src/index.ts");
+
+/** Minimal HTML page with an empty CSP meta tag and an inline script, so processing is easy to detect. */
+const pageHtml = `<!doctype html>
+<html>
+  <head>
+    <meta http-equiv="Content-Security-Policy" content="" />
+  </head>
+  <body>
+    <script>console.log("hi");</script>
+  </body>
+</html>
+`;
+
+const writePage = async (path: string) => {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, pageHtml);
+};
+
+describe("csp-bun-cli --pattern", () => {
+  test("only processes files matching the custom pattern", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "csp-pattern-"));
+
+    try {
+      const rootPath = join(workDir, "index.html");
+      const nestedPath = join(workDir, "about/index.html");
+
+      await writePage(rootPath);
+      await writePage(nestedPath);
+
+      // "*.html" (no `**/`) only matches top-level files, not the nested "about/index.html".
+      await $`bun run ${cliPath} --dir ${workDir} --pattern "*.html"`.quiet();
+
+      const rootContent = await Bun.file(rootPath).text();
+      const nestedContent = await Bun.file(nestedPath).text();
+
+      expect(rootContent).not.toContain('content=""');
+      expect(nestedContent).toContain('content=""');
+    } finally {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("defaults to recursively matching **/*.html when --pattern is omitted", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "csp-pattern-default-"));
+
+    try {
+      const rootPath = join(workDir, "index.html");
+      const nestedPath = join(workDir, "about/index.html");
+
+      await writePage(rootPath);
+      await writePage(nestedPath);
+
+      await $`bun run ${cliPath} --dir ${workDir}`.quiet();
+
+      const rootContent = await Bun.file(rootPath).text();
+      const nestedContent = await Bun.file(nestedPath).text();
+
+      expect(rootContent).not.toContain('content=""');
+      expect(nestedContent).not.toContain('content=""');
+    } finally {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("fatal error message includes the active pattern when nothing matches", async () => {
+    const workDir = await mkdtemp(join(tmpdir(), "csp-pattern-empty-"));
+
+    try {
+      const result = await $`bun run ${cliPath} --dir ${workDir} --pattern "*.nomatch"`.quiet().nothrow();
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr.toString()).toContain("*.nomatch");
+    } finally {
+      await rm(workDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Closes #27. Adds a `-p`/`--pattern` flag to `csp-bun-cli` that customizes the glob pattern used to discover HTML files under `--dir`. Default remains `**/*.html`, so this is fully backward compatible.

## Changes
- `packages/cli-bun/src/index.ts`: new `--pattern` option, wired into the existing `Glob` file-discovery scan; zero-match error now includes the active pattern
- `packages/cli-bun/README.md`: documents the new flag with usage examples (including Bun's native brace-expansion for matching multiple extensions)
- `test/cli-pattern.test.ts`: new unit tests covering custom-pattern narrowing, unchanged default behavior, and the updated zero-match error message
- `package.json`: registers the new test file in the `test` script

## Scope notes
This is CLI-only. The Vite plugin (`vite-bun`) doesn't need this since it already gets its exact HTML file list from Vite's own build manifest rather than a filesystem glob.

## Testing
- `bun run lint` passed
- `bun run build` passed
- `bun run build_fixtures && bun run test` passed (19 pass, including 3 new tests)

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)
